### PR TITLE
Only Create Backup Folders for System Directories with Save Data. 

### DIFF
--- a/Backup Saves.sh
+++ b/Backup Saves.sh
@@ -33,16 +33,33 @@ while read -r line; do
     line=$(cut -d '/' -f 2- <<< "$line") | ("${line/#//}")
     ROM_DIRS+=("$line")
 done < $TMP_FILE 
-
-for log in ${ROM_DIRS[@]}; do
-    if [ -z "$(ls -A $ROOT_DIR/$log)" ]; then #Skips directory if it's empty.
-        continue
-    fi
-    CHECKED_ROM_DIRS+=("$log") #This array only stores the names of the directories that aren't empty. 
-done
 }
 
 PruneGameDirs () { #This function removes any folders that are meant to be skipped.
+# for log in ${ROM_DIRS[@]}; do
+#     if [ -z "$(ls -A $ROOT_DIR/$log)" ]; then #Skips directory if it's empty.
+#         continue
+#     fi
+#     CHECKED_ROM_DIRS+=("$log") #This array only stores the names of the directories that aren't empty. 
+# done
+
+COUNTER=0
+for dir in ${ROM_DIRS[@]}; do #Checks if the directories actually have save files. 
+    for svfile in ${SAVE_TYPES[@]}; do 
+         files=$(ls $ROOT_DIR/$dir/*.$svfile 2> /dev/null | wc -l)
+         if [ "$files" -eq "0"]; then
+            continue
+        else 
+            ((COUNTER++))
+        fi
+    done
+    if [ "$COUNTER" -eq "0" ]; then
+        continue
+    else 
+        COUNTER=0
+        CHECKED_ROM_DIRS+=("$dir")
+done
+
 for skipped in ${SKIPPED_DIRS[@]}; do
     for fol in ${CHECKED_ROM_DIRS[@]}; do
         if [ "$fol" == "$skipped/" ]; then

--- a/Backup Saves.sh
+++ b/Backup Saves.sh
@@ -30,7 +30,8 @@ FindGameDirs () {
 printf "Finding ROM directories...\n"
 ls -d1 $ROOT_DIR/*/ > "$TMP_FILE" #Only shows parent rom directories.
 while read -r line; do
-    line=$(cut -d '/' -f 2- <<< "$line") | ("${line/#//}")
+    # line=$(cut -d '/' -f 2- <<< "$line") | ("${line/#//}")
+    line=$(cut -c 8- <<< "$line") #Removes the '/roms2/' from the array items.
     ROM_DIRS+=("$line")
 done < $TMP_FILE 
 }
@@ -43,21 +44,13 @@ PruneGameDirs () { #This function removes any folders that are meant to be skipp
 #     CHECKED_ROM_DIRS+=("$log") #This array only stores the names of the directories that aren't empty. 
 # done
 
-COUNTER=0
 for dir in ${ROM_DIRS[@]}; do #Checks if the directories actually have save files. 
     for svfile in ${SAVE_TYPES[@]}; do 
-         files=$(ls $ROOT_DIR/$dir/*.$svfile 2> /dev/null | wc -l)
-         if [ "$files" -eq "0"]; then
-            continue
-        else 
-            ((COUNTER++))
+        if ls "$ROOT_DIR/$dir" | grep -q ".*\.$svfile$"; then
+            CHECKED_ROM_DIRS+=("$dir")
+            break
         fi
     done
-    if [ "$COUNTER" -eq "0" ]; then
-        continue
-    else 
-        COUNTER=0
-        CHECKED_ROM_DIRS+=("$dir")
 done
 
 for skipped in ${SKIPPED_DIRS[@]}; do
@@ -121,7 +114,7 @@ if [ $? = 0 ]; then
     BackUpSaves
 elif [ $? = 1 ]; then
     printf "No action taken. Exiting Script..."
-    sleep 2
+    sleep 1
     KillControls 
     exit 1
 fi

--- a/Backup Saves.sh
+++ b/Backup Saves.sh
@@ -28,15 +28,16 @@ ROOT_DIR=${2:-"/roms2"} #ROOT Directory
 
 FindGameDirs () {
 printf "Finding ROM directories...\n"
-ls -d1 $ROOT_DIR/*/ > "$TMP_FILE" #Only shows parent rom directories.
+ls -d1 $ROOT_DIR/*/ > "$TMP_FILE" #Only shows parent directories.
 while read -r line; do
     line=$(cut -c 8- <<< "$line") #Removes the '/roms2/' from the array items.
     ROM_DIRS+=("$line")
-done < $TMP_FILE 
+done < $TMP_FILE
+rm "$TMP_FILE" 
 }
 
 PruneGameDirs () {
-printf "Finding System directories with save files..."
+printf "Finding System directories with save files...\n"
 for dir in ${ROM_DIRS[@]}; do #Checks if the directories actually have save files. 
     if [ $dir == "dreamcast/" ] && ls "$ROOT_DIR/$dir" | grep -q ".*\.bin$" ; then
         CHECKED_ROM_DIRS+=("$dir")

--- a/Backup Saves.sh
+++ b/Backup Saves.sh
@@ -30,7 +30,7 @@ FindGameDirs () {
 printf "Finding ROM directories...\n"
 ls -d1 $ROOT_DIR/*/ > "$TMP_FILE" #Only shows parent rom directories.
 while read -r line; do
-    line=$(cut -c 8- <<< "$line") #Removes the '/roms2/' from the array items.
+    line=$(cut -d '/' -f 2- <<< "$line") | ("${line/#//}")
     ROM_DIRS+=("$line")
 done < $TMP_FILE 
 

--- a/Backup Saves.sh
+++ b/Backup Saves.sh
@@ -30,21 +30,18 @@ FindGameDirs () {
 printf "Finding ROM directories...\n"
 ls -d1 $ROOT_DIR/*/ > "$TMP_FILE" #Only shows parent rom directories.
 while read -r line; do
-    # line=$(cut -d '/' -f 2- <<< "$line") | ("${line/#//}")
     line=$(cut -c 8- <<< "$line") #Removes the '/roms2/' from the array items.
     ROM_DIRS+=("$line")
 done < $TMP_FILE 
 }
 
-PruneGameDirs () { #This function removes any folders that are meant to be skipped.
-# for log in ${ROM_DIRS[@]}; do
-#     if [ -z "$(ls -A $ROOT_DIR/$log)" ]; then #Skips directory if it's empty.
-#         continue
-#     fi
-#     CHECKED_ROM_DIRS+=("$log") #This array only stores the names of the directories that aren't empty. 
-# done
-
+PruneGameDirs () {
+printf "Finding System directories with save files..."
 for dir in ${ROM_DIRS[@]}; do #Checks if the directories actually have save files. 
+    if [ $dir == "dreamcast/" ] && ls "$ROOT_DIR/$dir" | grep -q ".*\.bin$" ; then
+        CHECKED_ROM_DIRS+=("$dir")
+        continue
+    fi
     for svfile in ${SAVE_TYPES[@]}; do 
         if ls "$ROOT_DIR/$dir" | grep -q ".*\.$svfile$"; then
             CHECKED_ROM_DIRS+=("$dir")


### PR DESCRIPTION
Big Update.

The script will now only create backup folders of systems that have save files in them. Previously, the script only accounted if _any_ file existed in a directory and created a backup directory before checking for save files. 

This update will make the backup much faster as it only accounts for directories with save data, not just any file.

Currently, the script can only account for roms2/ directory. A future update will give it more flexibility, but I had to roll back the code that was supposed to make it flexible for the $ROOT_DIR. If anyone is curious I am referencing this commit 6f66bf184bbe1848854815c53ef4482df1fa9245 line 33-34. 

